### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cloudpi.pe


### PR DESCRIPTION
We bought the domain [cloudpi.pe](http://cloudpi.pe) for https://github.com/cloudpipe and much to our surprise when setting up cloudpipe.github.io, we got a build warning from GitHub:

```
The page build completed successfully, but returned the following warning:

CNAME already taken: cloudpi.pe

For information on troubleshooting Jekyll see:

  https://help.github.com/articles/using-jekyll-with-pages#troubleshooting

If you have any questions please contact us at https://github.com/contact.
```

After a little bit of digging, I found your repo and am hoping you would be willing to delete the CNAME file for me.
